### PR TITLE
Rename `Object` -> `Obj` as it is now a reserved word in php 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "glow/precore",
+    "name": "glowteam/precore",
     "description": "Common classes and utilities",
     "license": "MIT",
     "keywords": ["common"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "precore/precore",
+    "name": "glow/precore",
     "description": "Common classes and utilities",
     "license": "MIT",
     "keywords": ["common"],

--- a/src/precore/lang/Enum.php
+++ b/src/precore/lang/Enum.php
@@ -57,7 +57,7 @@ use ReflectionProperty;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Enum extends Object implements Comparable
+abstract class Enum extends Obj implements Comparable
 {
     private static $cache = [];
     private static $ordinals = [];

--- a/src/precore/lang/Obj.php
+++ b/src/precore/lang/Obj.php
@@ -29,7 +29,7 @@ use lf4php\LoggerFactory;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Object implements ObjectInterface
+abstract class Obj implements ObjectInterface
 {
     /**
      * @return ObjectClass

--- a/src/precore/util/FluentIterable.php
+++ b/src/precore/util/FluentIterable.php
@@ -27,7 +27,7 @@ use Countable;
 use Iterator;
 use IteratorAggregate;
 use OutOfBoundsException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use Traversable;
 
 /**
@@ -48,7 +48,7 @@ use Traversable;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class FluentIterable extends Object implements IteratorAggregate, Countable
+final class FluentIterable extends Obj implements IteratorAggregate, Countable
 {
     /**
      * @var IteratorAggregate

--- a/src/precore/util/Joiner.php
+++ b/src/precore/util/Joiner.php
@@ -25,7 +25,7 @@ namespace precore\util;
 
 use ArrayIterator;
 use BadMethodCallException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use Traversable;
 
@@ -46,7 +46,7 @@ use Traversable;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Joiner extends Object
+abstract class Joiner extends Obj
 {
     private $separator;
 

--- a/src/precore/util/Objects.php
+++ b/src/precore/util/Objects.php
@@ -23,7 +23,7 @@
 
 namespace precore\util;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use ReflectionClass;
 
@@ -34,7 +34,7 @@ use ReflectionClass;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class Objects extends Object
+final class Objects extends Obj
 {
     private function __construct()
     {

--- a/src/precore/util/Optional.php
+++ b/src/precore/util/Optional.php
@@ -25,7 +25,7 @@ namespace precore\util;
 
 use precore\lang\IllegalStateException;
 use precore\lang\NullPointerException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 
 /**
@@ -36,7 +36,7 @@ use precore\lang\ObjectInterface;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Optional extends Object
+abstract class Optional extends Obj
 {
     private static $ABSENT;
 

--- a/src/precore/util/Profiler.php
+++ b/src/precore/util/Profiler.php
@@ -23,7 +23,7 @@
 
 namespace precore\util;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 
 /**
  * <p> Helps collection execution times in a programmatic way.
@@ -40,7 +40,7 @@ use precore\lang\Object;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class Profiler extends Object
+final class Profiler extends Obj
 {
     const ENTRY_FORMAT = "%-13s%30s%10s.";
     const ENTRY_PREFIX = ' |-- ';

--- a/src/precore/util/Range.php
+++ b/src/precore/util/Range.php
@@ -27,7 +27,7 @@ use BadMethodCallException;
 use precore\lang\ClassCastException;
 use precore\lang\Comparable;
 use precore\lang\NullPointerException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use Traversable;
 
@@ -50,7 +50,7 @@ use Traversable;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class Range extends Object
+final class Range extends Obj
 {
     private static $ALL;
 
@@ -316,7 +316,7 @@ final class Range extends Object
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Cut extends Object implements Comparable
+abstract class Cut extends Obj implements Comparable
 {
     private $endpoint;
 

--- a/src/precore/util/Splitter.php
+++ b/src/precore/util/Splitter.php
@@ -25,7 +25,7 @@ namespace precore\util;
 
 use ArrayIterator;
 use Iterator;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use RuntimeException;
 use Traversable;
@@ -68,7 +68,7 @@ use Traversable;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class Splitter extends Object
+abstract class Splitter extends Obj
 {
     const UTF_8 = 'UTF-8';
 

--- a/src/precore/util/Stopwatch.php
+++ b/src/precore/util/Stopwatch.php
@@ -24,7 +24,7 @@
 namespace precore\util;
 
 use precore\lang\IllegalStateException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\util\concurrent\TimeUnit;
 use RuntimeException;
 
@@ -68,7 +68,7 @@ use RuntimeException;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class Stopwatch extends Object
+final class Stopwatch extends Obj
 {
     /**
      * @var Ticker

--- a/src/precore/util/ToStringHelper.php
+++ b/src/precore/util/ToStringHelper.php
@@ -25,7 +25,7 @@ namespace precore\util;
 
 use DateTime;
 use ErrorException;
-use precore\lang\Object;
+use precore\lang\Obj;
 
 /**
  * Can be used in ObjectInterface implementations for overriding toString() method.
@@ -34,7 +34,7 @@ use precore\lang\Object;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class ToStringHelper extends Object
+class ToStringHelper extends Obj
 {
     private $className;
 

--- a/src/precore/util/ToStringHelperItem.php
+++ b/src/precore/util/ToStringHelperItem.php
@@ -23,7 +23,7 @@
 
 namespace precore\util;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 
 /**
  * Class ToStringHelperItem
@@ -31,7 +31,7 @@ use precore\lang\Object;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class ToStringHelperItem extends Object
+final class ToStringHelperItem extends Obj
 {
     private $key;
     private $value;

--- a/src/precore/util/TryTo.php
+++ b/src/precore/util/TryTo.php
@@ -25,7 +25,7 @@ namespace precore\util;
 
 use Exception;
 use precore\lang\NullPointerException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 
 /**
@@ -34,7 +34,7 @@ use precore\lang\ObjectInterface;
  * @package precore\util
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-abstract class TryTo extends Object
+abstract class TryTo extends Obj
 {
     /**
      * Builder method for a try-catch-finally definition.

--- a/src/precore/util/UUID.php
+++ b/src/precore/util/UUID.php
@@ -24,7 +24,7 @@
 namespace precore\util;
 
 use InvalidArgumentException;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 use Serializable;
 
@@ -33,7 +33,7 @@ use Serializable;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-final class UUID extends Object implements Serializable
+final class UUID extends Obj implements Serializable
 {
     const FULL_PATTERN = '/^\{?[0-9a-f]{8}\-?[0-9a-f]{4}\-?[0-9a-f]{4}\-?[0-9a-f]{4}\-?[0-9a-f]{12}\}?$/i';
 

--- a/src/precore/util/concurrent/FileLock.php
+++ b/src/precore/util/concurrent/FileLock.php
@@ -23,13 +23,13 @@
 
 namespace precore\util\concurrent;
 
-use precore\lang\Object;
+use precore\lang\Obj;
 use SplFileInfo;
 
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class FileLock extends Object implements Lock
+class FileLock extends Obj implements Lock
 {
     /**
      * @var SplFileInfo

--- a/src/precore/util/concurrent/LockedRunnableWrapper.php
+++ b/src/precore/util/concurrent/LockedRunnableWrapper.php
@@ -24,7 +24,7 @@
 namespace precore\util\concurrent;
 
 use Exception;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\RunException;
 use precore\lang\Runnable;
 
@@ -35,7 +35,7 @@ use precore\lang\Runnable;
  *
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class LockedRunnableWrapper extends Object implements Runnable
+class LockedRunnableWrapper extends Obj implements Runnable
 {
     /**
      * @var Lock

--- a/tests/src/precore/lang/ObjectClassTest.php
+++ b/tests/src/precore/lang/ObjectClassTest.php
@@ -90,13 +90,13 @@ class ObjectClassTest extends PHPUnit_Framework_TestCase
      */
     public function shouldCastNullToEverything()
     {
-        $res = Object::objectClass()->cast(null);
+        $res = Obj::objectClass()->cast(null);
         self::assertNull($res);
     }
 
     public function testCast()
     {
-        $objectClass = new ObjectClass(Object::className());
+        $objectClass = new ObjectClass(Obj::className());
         $object = new Psr0Class();
         self::assertSame($object, $objectClass->cast($object));
     }
@@ -106,7 +106,7 @@ class ObjectClassTest extends PHPUnit_Framework_TestCase
      */
     public function testCastException()
     {
-        $objectClass = new ObjectClass(Object::className());
+        $objectClass = new ObjectClass(Obj::className());
         $objectClass->cast($this);
     }
 
@@ -118,15 +118,15 @@ class ObjectClassTest extends PHPUnit_Framework_TestCase
 
     public function testForName()
     {
-        $class1 = ObjectClass::forName(Object::className());
-        $class2 = Object::objectClass();
+        $class1 = ObjectClass::forName(Obj::className());
+        $class2 = Obj::objectClass();
         self::assertSame($class2, $class1);
     }
 
     public function testSlash()
     {
-        $class1 = ObjectClass::forName('\precore\lang\Object');
-        $class2 = ObjectClass::forName('precore\lang\Object');
+        $class1 = ObjectClass::forName('\precore\lang\Obj');
+        $class2 = ObjectClass::forName('precore\lang\Obj');
         self::assertSame($class1, $class2);
     }
 
@@ -139,7 +139,7 @@ class ObjectClassTest extends PHPUnit_Framework_TestCase
         self::assertTrue($thisClass->isAssignableFrom($thisClass));
         self::assertFalse($thisClass->isAssignableFrom($parentClass));
         $interfaceClass = ObjectClass::forName('\precore\lang\ObjectInterface');
-        self::assertTrue($interfaceClass->isAssignableFrom(ObjectClass::forName('\precore\lang\Object')));
+        self::assertTrue($interfaceClass->isAssignableFrom(ObjectClass::forName('\precore\lang\Obj')));
         self::assertTrue($interfaceClass->isAssignableFrom($interfaceClass));
     }
 }

--- a/tests/src/precore/lang/ObjectTest.php
+++ b/tests/src/precore/lang/ObjectTest.php
@@ -31,13 +31,13 @@ use PHPUnit_Framework_TestCase;
 class ObjectTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var SampleObject
+     * @var SampleObj
      */
     private $obj;
 
     public function setUp()
     {
-        $this->obj = new SampleObject();
+        $this->obj = new SampleObj();
     }
 
     public function testGetClassName()
@@ -47,7 +47,7 @@ class ObjectTest extends PHPUnit_Framework_TestCase
 
     public function testClassName()
     {
-        self::assertSame(__NAMESPACE__ . '\SampleObject', SampleObject::className());
+        self::assertSame(__NAMESPACE__ . '\SampleObject', SampleObj::className());
     }
 
     public function testHashCode()
@@ -68,35 +68,35 @@ class ObjectTest extends PHPUnit_Framework_TestCase
     public function testEquals()
     {
         self::assertFalse($this->obj->equals(null));
-        $obj2 = new SampleObject();
+        $obj2 = new SampleObj();
         self::assertFalse($this->obj->equals($obj2));
     }
 
     public function testObjectClass()
     {
-        self::assertEquals(SampleObject2::className(), SampleObject2::objectClass()->getName());
-        self::assertEquals(SampleObject::className(), SampleObject::objectClass()->getName());
-        self::assertSame(SampleObject::objectClass(), SampleObject::objectClass());
+        self::assertEquals(SampleObj2::className(), SampleObj2::objectClass()->getName());
+        self::assertEquals(SampleObj::className(), SampleObj::objectClass()->getName());
+        self::assertSame(SampleObj::objectClass(), SampleObj::objectClass());
     }
 
     public function testGetObjectClass()
     {
-        $object = new SampleObject();
-        self::assertEquals(SampleObject::objectClass()->getName(), $object->getObjectClass()->getName());
+        $object = new SampleObj();
+        self::assertEquals(SampleObj::objectClass()->getName(), $object->getObjectClass()->getName());
     }
 
     public function testGetLogger()
     {
-        self::assertInstanceOf('\lf4php\Logger', SampleObject::getLogger());
+        self::assertInstanceOf('\lf4php\Logger', SampleObj::getLogger());
     }
 }
 
-class SampleObject extends Object
+class SampleObj extends Obj
 {
     private $id;
 }
 
-class SampleObject2 extends Object
+class SampleObj2 extends Obj
 {
     private $id2;
 }

--- a/tests/src/precore/lang/Psr0Class.php
+++ b/tests/src/precore/lang/Psr0Class.php
@@ -26,6 +26,6 @@ namespace precore\lang;
 /**
  * @author Janos Szurovecz <szjani@szjani.hu>
  */
-class Psr0Class extends Object
+class Psr0Class extends Obj
 {
 }

--- a/tests/src/precore/util/ObjectsTest.php
+++ b/tests/src/precore/util/ObjectsTest.php
@@ -26,7 +26,7 @@ namespace precore\util;
 use ArrayIterator;
 use ArrayObject;
 use PHPUnit_Framework_TestCase;
-use precore\lang\Object;
+use precore\lang\Obj;
 use precore\lang\ObjectInterface;
 
 class ObjectsTest extends PHPUnit_Framework_TestCase
@@ -117,7 +117,7 @@ class ObjectsTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class String extends Object
+class String extends Obj
 {
     private $data;
 


### PR DESCRIPTION
I am starting this PR to get a conversation started as to how this would be best dealt with moving forward. Basically, in order for us to continue to use both `predaddy` and `precore` and move forward with php 7.2 I needed to rename the current `precore\lang\Object` to `precore\lang\Obj` because `Object` is now a reserved word.

This is fine, I forked your projects and went ahead and started making the change. The issue I ran into was when I installed the dependencies required to run the test suite.

There are numerous issues with some of the libraries required to run the tests. The first I ran into was an issue within `lisachenko/go-aop-php`. This package has (at the version 0.5.0 that precore requires) also got issues working with php 7. This package has since moved to a new organisation (`goaop/framework`), and fixed those errors, however, it has become pretty clear that we need to invest a fair bit more effort to bring `precore` and `predaddy` up to date.

To get things working for us temporarily, I have created our own forks, fixed the Object name issue and have ignored running the unit tests within this library itself, relying on our own (application level) unit tests instead. I also created some packages for these libraries on packagist (https://packagist.org/packages/glowteam).

There are a few questions that I have.

We are willing to commit to do the work that needs to be done to get this package updated to work with php 7 as we believe the library to be awesome! What I am however wondering is:

Would you be happy to have these changes merged back into your project, and would you be available/willing to merge these changes in as required?

Or

Would you simply prefer to move these packages into some other organisation and let us worry about them?

If you have any other ideas, please let me know.